### PR TITLE
large-scale MT fixes for UCX progression engine

### DIFF
--- a/include/ghex/transport_layer/ucx/communicator.hpp
+++ b/include/ghex/transport_layer/ucx/communicator.hpp
@@ -155,11 +155,12 @@ namespace gridtools {
                         gridtools::ghex::tl::cb::progress_status status;
                         int p = 0;
                         p+= ucp_worker_progress(m_ucp_sw);
-                        p+= ucp_worker_progress(m_ucp_sw);
-                        p+= ucp_worker_progress(m_ucp_sw);
+
+                        /* this is really important for large-scale multithreading */
+                        sched_yield();
+
                         status.m_num_sends = std::exchange(m_send_worker->m_progressed_sends, 0);
                         std::lock_guard<decltype(m_send_worker->mutex())> lock(m_send_worker->mutex());
-                        p+= ucp_worker_progress(m_ucp_rw);
                         p+= ucp_worker_progress(m_ucp_rw);
                         status.m_num_recvs = std::exchange(m_recv_worker->m_progressed_recvs, 0);
                         status.m_num_cancels = std::exchange(m_recv_worker->m_progressed_cancels, 0);

--- a/include/ghex/transport_layer/ucx/request.hpp
+++ b/include/ghex/transport_layer/ucx/request.hpp
@@ -148,14 +148,11 @@ namespace gridtools{
                         if (!m_req) return true;
 
                         ucp_worker_progress(m_req->m_send_worker->get());
-                        ucp_worker_progress(m_req->m_send_worker->get());
-                        ucp_worker_progress(m_req->m_send_worker->get());
+
+                        /* this is really important for large-scale multithreading */
+                        sched_yield();
 
                         std::lock_guard<decltype(m_req->m_send_worker->mutex())> lock(m_req->m_send_worker->mutex());
-                        ucp_worker_progress(m_req->m_recv_worker->get());
-
-                        // TODO sometimes causes a slowdown, e.g., in the ft_avail
-                        // test with 16 threads
                         ucp_worker_progress(m_req->m_recv_worker->get());
 
                         // check request status


### PR DESCRIPTION
Fix UCX backend performance for large number of threads:
1. `sched_yield` needs to be called once per `progress()` call. we could demand this from users, but maybe it's better to do it ourselves. Performance suffers a bit for small number of threads.
2. remove multiple UCP progress calls. Also this improves performance only for small number of threads, and probably only for the benchmarks. In real applications this should not matter. Leads to "lockups" with large number of threads.